### PR TITLE
fix: stop supertag-sync-validate-nodes mass-orphaning file nodes

### DIFF
--- a/.phrase/docs/CHANGE.md
+++ b/.phrase/docs/CHANGE.md
@@ -25,4 +25,4 @@
 - 2026-07-08: phase-concept-mentions-20260708/change_concept_mentions_20260708.md  # CJK concept mentions
 - 2026-07-11: phase-sync-integrity-20251226/change_sync_integrity_20251226.md  # persistence failover + stable mixed file-node identity/links
 - 2026-07-13: phase-git-sync-20260713/CHANGE.md  # Git 原生同步 P0/P1 加固与 release-gate 验收
-- 2026-07-14: phase-sync-integrity-20251226/change_sync_integrity_20251226.md  # PR #181 deferred deletion retry hardening
+- 2026-07-14: phase-sync-integrity-20251226/change_sync_integrity_20251226.md  # PR #181 retry hardening + PR #182 file-node identity validation

--- a/.phrase/docs/ISSUES.md
+++ b/.phrase/docs/ISSUES.md
@@ -13,3 +13,4 @@
 - issue011 [ ] file-node 身份不稳定且 Denote/Org-ID 链接语义泄漏到多层（phase-sync-integrity-20251226/issue_sync_integrity_20260711_file_node_identity.md）
 - issue012 [ ] concept promote 先产生副作用且 mention 上下文/冲突处理不稳定（phase-concept-mentions-20260708/issue_concept_mentions_20260711_review.md）
 - issue014 [ ] snapshot guard 延迟删除在重启或 worker 异常后失去重试（实现完成，待用户验收；phase-sync-integrity-20251226/issue_sync_integrity_20260714_deferred_retry.md）
+- issue015 [ ] file-node 验证忽略持久身份并保留失效节点（phase-sync-integrity-20251226/issue_sync_integrity_20260714_file_node_validation.md）

--- a/.phrase/phases/phase-sync-integrity-20251226/change_sync_integrity_20251226.md
+++ b/.phrase/phases/phase-sync-integrity-20251226/change_sync_integrity_20251226.md
@@ -1,5 +1,21 @@
 # Sync Integrity Change Log
 
+## 2026-07-14 — task016 / issue015
+
+- Modify `supertag-services-sync.el`：file-node validation 改为读取节点自身的
+  `:link-type`；Org-ID 校验顶部 `:ID:`，Denote 校验 `#+IDENTIFIER:`，未知或缺失
+  link type 的 legacy node 继续以文件存在为保守兜底。
+- Modify `test/sync-worker-regression-test.el`：锁定 Org-ID 与 Denote 身份替换后旧节点
+  orphan、新节点成为文件唯一入口的行为；保留 legacy/live、deleted file 与 heading
+  回归。
+- Modify `CHANGELOG.org`：删除“所有 file-node 只按文件存在校验”的错误承诺，记录
+  per-node identity 与 legacy fallback 的实际边界。
+- Add `issue_sync_integrity_20260714_file_node_validation.md`：登记 PR #182 的身份变化
+  回归与用户验收状态。
+
+验证：sync-worker 6/6；完整 ERT 119/119；byte-compile、bash 语法和
+`git diff --check` 通过。
+
 ## 2026-07-14 — task015 / issue014
 
 - Modify `supertag-services-sync.el`：移除 async processor 的重复 sync-state 推进，

--- a/.phrase/phases/phase-sync-integrity-20251226/issue_sync_integrity_20260714_file_node_validation.md
+++ b/.phrase/phases/phase-sync-integrity-20251226/issue_sync_integrity_20260714_file_node_validation.md
@@ -1,0 +1,48 @@
+# issue015 [ ] file-node 验证忽略持久身份并保留失效节点
+
+## Environment
+
+- PR: #182 `fix/validate-nodes-file-node-orphaning`
+- Baseline: `ac914e3`
+- Default Org-roam file-node policy and Denote-compatible stores
+
+## Repro / Actual
+
+把文件顶部的 `:ID:` 从 `old-file-id` 改为 `new-file-id`，同步会创建新 file node。
+PR #182 的 validation 只检查文件路径是否存在，因此旧、新两个 level-0 node 都继续
+指向同一文件；`supertag-find-file-node` 还可能选中旧 ID。
+
+## Expected
+
+- `:link-type id` 的 node 只在顶部 `:ID:` 仍等于自身 ID 时有效。
+- `:link-type denote` 的 node 只在 `#+IDENTIFIER:` 仍等于自身 ID 时有效。
+- 缺少 `:link-type` 的旧数据在文件存在时保留，避免再次触发 mass orphan。
+- 文件删除时所有 file node 仍进入 orphan 流程。
+
+## Investigation / Root Cause
+
+PR #182 正确区分了 file node 与 heading node，但把所有 file node 的有效性缩减为
+`file-exists-p`。这覆盖了当前已经持久化的 `:link-type` 语义，并回归了原本对
+Org-ID 身份变化有效的清理行为。
+
+## Planned Fix
+
+复用现有 file header parser，由 node 自己的 `:link-type` 选择 Org ID 或 Denote
+identifier；只有 legacy node 回退到文件存在判断。验证不依赖当前全局 policy。
+
+## Verification
+
+- [x] Org-ID identity matching / changed
+- [x] Denote identity matching / changed
+- [x] Legacy live file / deleted file / missing heading ID
+- [x] Full ERT 119/119 and byte compilation
+
+## User Confirmation
+
+- [ ] 等待修复推送后由用户验收。
+
+## Related
+
+- PR: #182
+- Task: task016
+- Existing identity issue: issue011

--- a/.phrase/phases/phase-sync-integrity-20251226/plan_sync_integrity_20251226.md
+++ b/.phrase/phases/phase-sync-integrity-20251226/plan_sync_integrity_20251226.md
@@ -1,0 +1,57 @@
+# plan_sync_integrity_20251226
+
+## Milestones
+
+1. 完整梳理当前同步数据流与破坏性变更路径。
+2. 设计“同步快照状态机”（availability + completeness）。
+3. 落地为最小改动的同步流水线：采样 → 对比 → 应用。
+4. 兼容性验证与回滚策略确认。
+5. sync-state 与 vault/data-directory 绑定并在切换时重载。
+6. Table view Refs 列默认作为 node-reference 字段，支持直接编辑引用，并合并 add-reference 关系。
+7. 保证 persistence 显式 DB 候选优先于 configured/default/legacy/snapshot，并保留失败诊断。
+8. 将 file-node 稳定身份、链接编码与 backlink 存储语义拆到正确 seam。
+9. 按每个 file-node 的 link type 验证持久身份，同时保留 legacy 数据的非破坏性兜底。
+
+## Scope
+
+- `supertag-services-sync.el` 同步流程与状态管理。
+- `supertag-core-persistence.el` 的写盘风险边界评估（不改数据格式）。
+- 启动/切换流程中的同步触发时机。
+- View Table：Refs 列默认 node-reference 字段（可编辑），并在全局字段模式下自动创建/关联。
+- Persistence：候选去重顺序与显式文件 failover 语义。
+- File node：仅识别持久化身份；节点自身携带 link type；relation 不猜测兼容模式。
+
+## Priorities
+
+- P0: 目录不可用时不发生破坏性同步或写盘覆盖。
+- P1: 保持文件删除语义与现有用户行为不变。
+- P2: 简化同步流程与状态判断，减少特殊情况。
+- P0: `supertag-load-store FILE` 必须先尝试 FILE，不能静默加载其他数据库。
+- P0: file-node 身份变化必须淘汰旧节点，legacy node 不得因缺少新元数据被误删。
+
+## State Machine (Design)
+
+- 状态：`unavailable` / `partial` / `complete`。
+- 采样阶段生成快照状态，再进入对比与应用。
+- 只有 `complete` 允许删除、orphan 标记、sync-state 清理。
+- `partial/unavailable` 只做增量更新或直接跳过，不产生破坏性变更。
+
+## Risks & Dependencies
+
+- 风险：误把“不可用”当“删除”仍会导致数据污染。
+- 依赖：sync-state 与 store 的一致性需要可观察状态。
+- 兼容性：必须维持旧数据与旧行为可用。
+- 风险：手动切换 data-directory 时状态未重载导致错配。
+- 风险：显式恢复文件与 snapshot 重名时，去重可能改变候选优先级并加载错误数据库。
+- 风险：只按文件存在验证 file-node 会在身份变化后留下重复节点和错误链接。
+
+## Rollback
+
+- 新状态机以开关形式接入，保留旧流程入口可即时切回。
+- 回滚只需关闭新状态判断；不做数据迁移，不改变现有 store 格式。
+- 出现异常时先暂停自动同步，待目录可用后手动全量 rescan 恢复一致性。
+
+## Feature Toggle
+
+- `supertag-sync-snapshot-guard` 默认开启；关闭时回退旧同步入口。
+- `supertag-sync--check-and-sync` 作为统一入口，内部选择新/旧流程。

--- a/.phrase/phases/phase-sync-integrity-20251226/task_sync_integrity_20251226.md
+++ b/.phrase/phases/phase-sync-integrity-20251226/task_sync_integrity_20251226.md
@@ -83,3 +83,13 @@
   - 验证方式：跨重启与 worker 异常回归均 RED→GREEN；完整 ERT 116/116；aggregate 3/3
   - 影响范围：`supertag-services-sync.el`、`test/sync-worker-regression-test.el`、
     `test/run-tests.sh`、`CHANGELOG.org`
+
+- task016 [x] 按 file-node 自身 link type 验证持久身份（issue015）
+  - 产出：Org-ID/Denote file node 校验对应文件身份；缺少 link type 的 legacy node
+    继续以文件存在为安全兜底
+  - 验证方式：Org-ID 与 Denote 的匹配/变更回归；legacy/live、deleted file 与 heading
+    回归；完整 ERT、byte-compile、`git diff --check`
+  - 影响范围：`supertag-services-sync.el`、`test/sync-worker-regression-test.el`、
+    `CHANGELOG.org`
+  - 完成：Org-ID/Denote 身份变更回归、legacy/deleted/heading 回归和完整 ERT
+    119/119 通过；issue015 保持待用户验收状态

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,16 +1,13 @@
 * Changelog
 * [Unreleased]
 ** Bug fixes
-- Fixed =supertag-sync-validate-nodes= mass-orphaning every file node:
-  it marked a node orphaned when the node ID was absent from the file
-  body, but a level-0 file node's UUID is never written into the file
-  as an =:ID:= drawer, so the check always failed and orphaned every
-  file whose file still existed. This produced =GC aborted= warnings
-  (the mass-deletion safety cap correctly refusing to delete ~92% of
-  nodes). Validation now checks file nodes by file existence (valid
-  while the file exists, orphaned once it is gone) and heading nodes by
-  ID presence, so deleted-file cleanup still works for both. Regression
-  tests cover the kept, deleted-file, and missing-heading cases.
+- Fixed =supertag-sync-validate-nodes= mass-orphaning legacy file nodes that
+  predate persisted identity metadata. Current file nodes are validated by
+  their own link type: Org-ID nodes match the top-level =:ID:= and Denote
+  nodes match =#+IDENTIFIER:=. Legacy nodes without =:link-type= fall back to
+  file existence, while deleted files and missing headings are still
+  orphaned. Identity changes now retire the old file node instead of leaving
+  two nodes pointing at one file.
 - Fixed =Symbol's value as variable is void: --cl-block-...--= errors
   (seen from the async sync worker when destructive sync is disallowed):
   eight functions used =cl-return-from= inside a plain =defun=, which

--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,6 +1,16 @@
 * Changelog
 * [Unreleased]
 ** Bug fixes
+- Fixed =supertag-sync-validate-nodes= mass-orphaning every file node:
+  it marked a node orphaned when the node ID was absent from the file
+  body, but a level-0 file node's UUID is never written into the file
+  as an =:ID:= drawer, so the check always failed and orphaned every
+  file whose file still existed. This produced =GC aborted= warnings
+  (the mass-deletion safety cap correctly refusing to delete ~92% of
+  nodes). Validation now checks file nodes by file existence (valid
+  while the file exists, orphaned once it is gone) and heading nodes by
+  ID presence, so deleted-file cleanup still works for both. Regression
+  tests cover the kept, deleted-file, and missing-heading cases.
 - Fixed =Symbol's value as variable is void: --cl-block-...--= errors
   (seen from the async sync worker when destructive sync is disallowed):
   eight functions used =cl-return-from= inside a plain =defun=, which

--- a/supertag-services-sync.el
+++ b/supertag-services-sync.el
@@ -840,6 +840,13 @@ Includes the node's ID to ensure absolute uniqueness of the state fingerprint."
                    "|")))
     (secure-hash 'sha1 (format "%s|%s" id payload))))
 
+(defun supertag-node-file-node-p (node)
+  "Return non-nil when NODE is a file node (level 0).
+File nodes represent the file itself; their UUID is never written into the
+org file as an :ID: drawer, so heading-oriented sync and validation must skip
+them."
+  (eq (plist-get node :level) 0))
+
 (defun supertag-node-mark-deleted-from-file (id)
   "Mark a node as deleted from its file by setting its :file property to nil.
 This does not remove the node from the store immediately."
@@ -1038,7 +1045,7 @@ COUNTERS is a plist for tracking :nodes-created, :nodes-updated, and :nodes-dele
                  (old-node-props (cdr existing-node-pair))
                  (new-node-props (gethash id current-nodes-in-file)))
             ;; ponytail: file nodes (level 0) are not managed by heading sync
-            (unless (eq (plist-get old-node-props :level) 0)
+            (unless (supertag-node-file-node-p old-node-props)
             (cond
              ((null new-node-props)
               (if allow-destructive
@@ -1101,7 +1108,7 @@ COUNTERS is a plist for tracking :nodes-created, :nodes-updated, and :nodes-dele
                    (new-node-props (gethash id current-nodes-in-file)))
               ;; Skip file nodes (level 0) - they are NOT orphaned while file exists
               ;; ponytail: file node lifecycle mirrors the file itself
-              (unless (eq (plist-get old-node-props :level) 0)
+              (unless (supertag-node-file-node-p old-node-props)
               ;; If node exists in store but not in file, mark it as orphaned
               (when (null new-node-props)
                 (let ((db-node (supertag-node-get id)))
@@ -1386,13 +1393,23 @@ COUNTERS is a plist for tracking changes."
    (lambda (id node)
      (let ((file (plist-get node :file))
            (type (plist-get node :type)))
-       ;; Only check nodes that are supposed to be in a file, and are of type :node.
+       ;; Only check :node entities that claim to live in a file.
        ;; If :file is already nil, it's already an orphan.
        (when (and file (eq type :node))
-         (unless (supertag-sync--id-exists-in-file-p id file)
-           (supertag-node-mark-deleted-from-file id)
-           (when counters
-             (setf (plist-get counters :nodes-deleted) (1+ (plist-get counters :nodes-deleted))))))))))
+         ;; A file node (level 0) is valid iff its file still exists: its UUID
+         ;; is never written into the org file as an :ID: drawer, so the
+         ;; id-in-file check below would wrongly orphan every file node whose
+         ;; file still exists (mass `:file nil' corruption -> aborted GC). A
+         ;; heading node is valid iff its ID still appears in the file. This
+         ;; keeps deleted-file cleanup working for both kinds.
+         (let ((stale (if (supertag-node-file-node-p node)
+                          (not (file-exists-p file))
+                        (not (supertag-sync--id-exists-in-file-p id file)))))
+           (when stale
+             (supertag-node-mark-deleted-from-file id)
+             (when counters
+               (setf (plist-get counters :nodes-deleted)
+                     (1+ (plist-get counters :nodes-deleted)))))))))))
 
 
 ;; --- Org Parser ---

--- a/supertag-services-sync.el
+++ b/supertag-services-sync.el
@@ -842,9 +842,7 @@ Includes the node's ID to ensure absolute uniqueness of the state fingerprint."
 
 (defun supertag-node-file-node-p (node)
   "Return non-nil when NODE is a file node (level 0).
-File nodes represent the file itself; their UUID is never written into the
-org file as an :ID: drawer, so heading-oriented sync and validation must skip
-them."
+File nodes represent file-level identity rather than Org headings."
   (eq (plist-get node :level) 0))
 
 (defun supertag-node-mark-deleted-from-file (id)
@@ -1383,6 +1381,18 @@ Returns t if the node ID is found, nil otherwise."
          (goto-char (point-min))
          (re-search-forward (concat ":ID:[ \t]+" (regexp-quote id)) nil t))))
 
+(defun supertag-sync--file-identity-matches-p (id node file)
+  "Return non-nil when NODE's persisted identity in FILE still equals ID."
+  (let ((policy (pcase (plist-get node :link-type)
+                  ('id 'org-id)
+                  ('denote 'denote))))
+    (and policy
+         (file-exists-p file)
+         (with-temp-buffer
+           (insert-file-contents-literally file)
+           (let ((org-supertag-file-id-source policy))
+             (equal id (plist-get (supertag-sync--parse-file-header) :id)))))))
+
 (defun supertag-sync-validate-nodes (&optional counters)
   "Validate all nodes in the database against their source files.
 This function iterates through all nodes in the store and checks if they
@@ -1396,15 +1406,18 @@ COUNTERS is a plist for tracking changes."
        ;; Only check :node entities that claim to live in a file.
        ;; If :file is already nil, it's already an orphan.
        (when (and file (eq type :node))
-         ;; A file node (level 0) is valid iff its file still exists: its UUID
-         ;; is never written into the org file as an :ID: drawer, so the
-         ;; id-in-file check below would wrongly orphan every file node whose
-         ;; file still exists (mass `:file nil' corruption -> aborted GC). A
-         ;; heading node is valid iff its ID still appears in the file. This
-         ;; keeps deleted-file cleanup working for both kinds.
-         (let ((stale (if (supertag-node-file-node-p node)
-                          (not (file-exists-p file))
-                        (not (supertag-sync--id-exists-in-file-p id file)))))
+         ;; Current file nodes carry their identity kind.  Legacy nodes do
+         ;; not, so preserve them while the file exists rather than guessing.
+         (let* ((file-node (supertag-node-file-node-p node))
+                (link-type (plist-get node :link-type))
+                (stale
+                 (cond
+                  ((not file-node)
+                   (not (supertag-sync--id-exists-in-file-p id file)))
+                  ((not (file-exists-p file)) t)
+                  ((memq link-type '(id denote))
+                   (not (supertag-sync--file-identity-matches-p id node file)))
+                  (t nil))))
            (when stale
              (supertag-node-mark-deleted-from-file id)
              (when counters

--- a/test/sync-worker-regression-test.el
+++ b/test/sync-worker-regression-test.el
@@ -144,14 +144,10 @@ the old mtime until destructive cleanup is allowed."
             (should (equal supertag-async--queue (list file)))))
       (ignore-errors (delete-file file)))))
 
-(ert-deftest supertag-sync-validate-nodes-keeps-file-nodes ()
-  "`supertag-sync-validate-nodes' validates a file node by file existence.
-A file node's UUID is never written into the org file as an :ID: drawer, so
-`supertag-sync--id-exists-in-file-p' always fails for it; validating file
-nodes that way orphans every file whose file still exists (mass `:file nil'
-corruption, then aborted GC). A file node whose file EXISTS is kept, a file
-node whose file is GONE is orphaned, and a heading node whose ID is absent
-from the file is orphaned."
+(ert-deftest supertag-sync-validate-nodes-keeps-legacy-file-nodes ()
+  "Validate legacy file nodes without identity metadata by file existence.
+Such nodes predate `:link-type', so a live file is the only safe evidence.
+A deleted-file node and a heading whose ID is absent are still orphaned."
   (let* ((file (make-temp-file "supertag-validate-" nil ".org"
                                "#+title: ai\n* Heading\nno id drawer here\n"))
          (gone-file (concat (make-temp-name
@@ -181,6 +177,45 @@ from the file is orphaned."
           (should (member "MISSING-HEADING" marked))
           (should (= (length marked) 2)))
       (ignore-errors (delete-file file)))))
+
+(defun supertag-sync-worker-test--identity-replacement
+    (link-type contents old-id new-id)
+  "Verify identity replacement for LINK-TYPE using CONTENTS and node IDs."
+  (let* ((tmp (make-temp-file "supertag-validate-identity-" t))
+         (file (expand-file-name "note.org" tmp))
+         (supertag-data-directory tmp)
+         (supertag-db-file (expand-file-name "supertag-db.el" tmp))
+         (supertag--store nil)
+         (counters (list :nodes-deleted 0)))
+    (unwind-protect
+        (progn
+          (with-temp-file file
+            (insert contents))
+          (supertag--ensure-store)
+          (supertag-node-create
+           (list :id old-id :type :node :level 0 :link-type link-type
+                 :file file :title "Old"))
+          (supertag-node-create
+           (list :id new-id :type :node :level 0 :link-type link-type
+                 :file file :title "New"))
+          (supertag-sync-validate-nodes counters)
+          (should-not (plist-get (supertag-node-get old-id) :file))
+          (should (equal (plist-get (supertag-node-get new-id) :file) file))
+          (should (equal (car (supertag-find-file-node file)) new-id))
+          (should (= (plist-get counters :nodes-deleted) 1)))
+      (ignore-errors (delete-directory tmp t)))))
+
+(ert-deftest supertag-sync-validate-nodes-orphans-replaced-org-id ()
+  "A file node stops owning a file after its top-level Org ID changes."
+  (supertag-sync-worker-test--identity-replacement
+   'id ":PROPERTIES:\n:ID: new-file-id\n:END:\n#+TITLE: Note\n"
+   "old-file-id" "new-file-id"))
+
+(ert-deftest supertag-sync-validate-nodes-orphans-replaced-denote-id ()
+  "A file node stops owning a file after its Denote identifier changes."
+  (supertag-sync-worker-test--identity-replacement
+   'denote "#+TITLE: Note\n#+IDENTIFIER: new-denote-id\n"
+   "old-denote-id" "new-denote-id"))
 
 (provide 'sync-worker-regression-test)
 ;;; sync-worker-regression-test.el ends here

--- a/test/sync-worker-regression-test.el
+++ b/test/sync-worker-regression-test.el
@@ -144,5 +144,43 @@ the old mtime until destructive cleanup is allowed."
             (should (equal supertag-async--queue (list file)))))
       (ignore-errors (delete-file file)))))
 
+(ert-deftest supertag-sync-validate-nodes-keeps-file-nodes ()
+  "`supertag-sync-validate-nodes' validates a file node by file existence.
+A file node's UUID is never written into the org file as an :ID: drawer, so
+`supertag-sync--id-exists-in-file-p' always fails for it; validating file
+nodes that way orphans every file whose file still exists (mass `:file nil'
+corruption, then aborted GC). A file node whose file EXISTS is kept, a file
+node whose file is GONE is orphaned, and a heading node whose ID is absent
+from the file is orphaned."
+  (let* ((file (make-temp-file "supertag-validate-" nil ".org"
+                               "#+title: ai\n* Heading\nno id drawer here\n"))
+         (gone-file (concat (make-temp-name
+                             (expand-file-name "supertag-validate-gone-"
+                                               temporary-file-directory))
+                            ".org"))
+         (marked '()))
+    (unwind-protect
+        (cl-letf (((symbol-function 'supertag-traverse-nodes)
+                   (lambda (fn)
+                     (funcall fn "FILE-NODE-UUID"
+                              (list :id "FILE-NODE-UUID" :type :node
+                                    :level 0 :file file :title "ai"))
+                     (funcall fn "FILE-NODE-GONE"
+                              (list :id "FILE-NODE-GONE" :type :node
+                                    :level 0 :file gone-file :title "gone-file"))
+                     (funcall fn "MISSING-HEADING"
+                              (list :id "MISSING-HEADING" :type :node
+                                    :level 1 :file file :title "gone"))))
+                  ((symbol-function 'supertag-node-mark-deleted-from-file)
+                   (lambda (id) (push id marked))))
+          (supertag-sync-validate-nodes)
+          ;; File node with a live file is kept; the deleted-file node and the
+          ;; genuinely missing heading are orphaned.
+          (should-not (member "FILE-NODE-UUID" marked))
+          (should (member "FILE-NODE-GONE" marked))
+          (should (member "MISSING-HEADING" marked))
+          (should (= (length marked) 2)))
+      (ignore-errors (delete-file file)))))
+
 (provide 'sync-worker-regression-test)
 ;;; sync-worker-regression-test.el ends here


### PR DESCRIPTION
## Problem

On startup, `org-supertag` could report that the GC safety cap rejected a mass
deletion. The cap was working: `supertag-sync-validate-nodes` had already marked
legacy level-0 file nodes as orphaned because their IDs were not present as
heading drawers.

The initial fix treated every live level-0 node as valid. That stopped the mass
orphaning, but it also left stale current-format nodes behind when a file's
persisted Org-ID or Denote identifier changed.

## Fix

Validation now follows the identity metadata stored on each node:

- `:link-type id` must match the file's top-level `:ID:`.
- `:link-type denote` must match `#+IDENTIFIER:`.
- Legacy nodes without a recognized `:link-type` use file existence as the
  conservative fallback, avoiding destructive guesses.
- Deleted files still orphan file nodes.
- Heading nodes still use the existing in-file ID validation.

This is independent of the machine's current global file-node policy. Changing
a supported file identity retires the old node, while the replacement remains
the file's addressable node.

`supertag-node-file-node-p` also replaces the duplicated level-0 shape checks at
the sync call sites.

## Tests

`test/sync-worker-regression-test.el` covers:

- live legacy file node retained;
- deleted file node orphaned;
- missing heading ID orphaned;
- Org-ID replacement: old node orphaned, new node retained and selected;
- Denote replacement under the default Org-roam global policy, proving that
  per-node identity controls validation.

Verification:

- sync-worker: 6/6 passed
- full ERT: 119/119 passed
- byte compilation completed successfully
- `git diff --check` passed
